### PR TITLE
Implement Custom User-Agent to prevent firewall banning

### DIFF
--- a/app/src/main/java/org/docspell/docspellshare/http/HttpRequest.java
+++ b/app/src/main/java/org/docspell/docspellshare/http/HttpRequest.java
@@ -35,6 +35,7 @@ public final class HttpRequest {
                   ConnectionSpec.CLEARTEXT))
           .readTimeout(5, TimeUnit.MINUTES)
           .writeTimeout(5, TimeUnit.MINUTES)
+          .addInterceptor(new UserAgentInterceptor())
           .socketFactory(new RestrictedSocketFactory(CHUNK_SIZE))
           .followRedirects(true)
           .followSslRedirects(true)
@@ -48,7 +49,7 @@ public final class HttpRequest {
     this.data = data;
   }
 
-  public int execute(ProgressListener progressListener) throws IOException {
+  public Response execute(ProgressListener progressListener) throws IOException {
     MultipartBody.Builder body = new MultipartBody.Builder().setType(MultipartBody.FORM);
     for (DataPart dp : data) {
       body.addFormDataPart("file", dp.getName(), createPartBody(dp, progressListener));
@@ -56,7 +57,7 @@ public final class HttpRequest {
 
     Request req = new Request.Builder().url(url).post(body.build()).build();
     Response response = client.newCall(req).execute();
-    return response.code();
+    return response;
   }
 
   public static Builder newBuilder() {

--- a/app/src/main/java/org/docspell/docspellshare/http/UploadManager.java
+++ b/app/src/main/java/org/docspell/docspellshare/http/UploadManager.java
@@ -7,6 +7,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
+import okhttp3.Response;
+
 public final class UploadManager {
 
   private static final UploadManager INSTANCE = new UploadManager();
@@ -46,8 +48,10 @@ public final class UploadManager {
     public void run() {
       Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
       try {
-        int code = request.execute(listener);
-        listener.onFinish(code);
+        Response resp = request.execute(listener);
+        listener.onFinish(resp.code());
+        resp.close();
+
       } catch (IOException e) {
         Log.e("upload", "Error uploading!", e);
         listener.onException(e);

--- a/app/src/main/java/org/docspell/docspellshare/http/UploadManager.java
+++ b/app/src/main/java/org/docspell/docspellshare/http/UploadManager.java
@@ -48,10 +48,13 @@ public final class UploadManager {
     public void run() {
       Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
       try {
-        Response resp = request.execute(listener);
-        listener.onFinish(resp.code());
-        resp.close();
-
+        Response resp = null;
+        try {
+          resp = request.execute(listener);
+          listener.onFinish(resp.code());
+        } finally {
+          resp.close();
+        }
       } catch (IOException e) {
         Log.e("upload", "Error uploading!", e);
         listener.onException(e);

--- a/app/src/main/java/org/docspell/docspellshare/http/UserAgentInterceptor.java
+++ b/app/src/main/java/org/docspell/docspellshare/http/UserAgentInterceptor.java
@@ -1,0 +1,45 @@
+package org.docspell.docspellshare.http;
+
+import android.os.Build;
+
+import org.docspell.docspellshare.BuildConfig;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Adds a custom {@code User-Agent} header to OkHttp requests.
+ */
+public class UserAgentInterceptor implements Interceptor {
+
+    public final String userAgent;
+
+    public UserAgentInterceptor(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    public UserAgentInterceptor() {
+        this(String.format(Locale.US,
+                "%s/%s (Android %s; %s; %s %s; %s)",
+                "Docspellshare",
+                BuildConfig.VERSION_NAME,
+                Build.VERSION.RELEASE,
+                Build.MODEL,
+                Build.BRAND,
+                Build.DEVICE,
+                Locale.getDefault().getLanguage()));
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request userAgentRequest = chain.request()
+                .newBuilder()
+                .header("User-Agent", userAgent)
+                .build();
+        return chain.proceed(userAgentRequest);
+    }
+}


### PR DESCRIPTION
This PR will Fix #51 .
The original error occured due to the ban of the IP on the Firewall.
Therefore, HTTP/2 Session could not be established.
The reason for blacklisting was an "incorrect"/"insufficient" user-agent.

This PR implements an UserAgentIntercepter to add a app related User-Agent with every Request.
This PR does also implement a `Response.close()` call.