### PR TITLE
Implemented parser to retrieve displayname for files/content

### DIFF
--- a/app/src/main/java/org/docspell/docspellshare/activity/ShareActivity.java
+++ b/app/src/main/java/org/docspell/docspellshare/activity/ShareActivity.java
@@ -160,15 +160,18 @@ public class ShareActivity extends AppCompatActivity {
             cursor = getContentResolver().query(
                     uri,
                     new String[]{
-                        MediaStore.Images.ImageColumns.DISPLAY_NAME
+                            MediaStore.Images.ImageColumns.DISPLAY_NAME
                     },
                     null,
                     null,
                     null
             );
             if (cursor != null && cursor.moveToFirst()) {
-                fileName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+                fileName = cursor.getString(cursor.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME));
             }
+        } catch (IllegalArgumentException e) {
+            // exception will be thrown if index is out of range (e.x. -1).
+            // No need to handle the exception since the HttpRequest Class will fallback to Document ID
         } finally {
             if (cursor != null) {
                 cursor.close();

--- a/app/src/main/java/org/docspell/docspellshare/activity/ShareActivity.java
+++ b/app/src/main/java/org/docspell/docspellshare/activity/ShareActivity.java
@@ -167,11 +167,7 @@ public class ShareActivity extends AppCompatActivity {
                     null
             );
             if (cursor != null && cursor.moveToFirst()) {
-                fileName = cursor.getString(
-                        cursor.getColumnIndex(
-                                OpenableColumns.DISPLAY_NAME
-                        )
-                );
+                fileName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
             }
         } finally {
             if (cursor != null) {

--- a/app/src/main/java/org/docspell/docspellshare/http/HttpRequest.java
+++ b/app/src/main/java/org/docspell/docspellshare/http/HttpRequest.java
@@ -22,6 +22,7 @@ import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
 import org.docspell.docspellshare.data.Option;
+import org.docspell.docspellshare.util.Strings;
 import org.docspell.docspellshare.util.Uris;
 
 public final class HttpRequest {
@@ -67,7 +68,7 @@ public final class HttpRequest {
     private final List<DataPart> parts = new ArrayList<>();
     private String url;
 
-    public Builder addFile(ContentResolver resolver, Uri data) {
+    public Builder addFile(ContentResolver resolver, Uri data, String fileName) {
       parts.add(
           new DataPart() {
             @Override
@@ -77,7 +78,11 @@ public final class HttpRequest {
 
             @Override
             public String getName() {
-              return data.getLastPathSegment();
+              if (Strings.isNullOrBlank(fileName)) {
+                return data.getLastPathSegment();
+              } else {
+                return fileName;
+              }
             }
 
             @Override
@@ -131,7 +136,7 @@ public final class HttpRequest {
       @Override
       public void writeTo(@NonNull BufferedSink sink) throws IOException {
         try (InputStream in = part.getData();
-            Source source = Okio.source(in)) {
+             Source source = Okio.source(in)) {
           long total = 0;
           long read;
           while ((read = source.read(sink.getBuffer(), CHUNK_SIZE)) != -1) {


### PR DESCRIPTION
As already shown in the Issue #31 , The current solution is based on last segment of uri. Depending on the APP, the file get's shared, it MAY be the actual display name, but in most cases it will be the android document ID.

Therefore it is necessary to read the files Metadata to obtain the actual title / name of the file.

Here is some reference:
https://developer.android.com/training/secure-file-sharing/retrieve-info?hl=en

fixes #31 